### PR TITLE
Update Common.py

### DIFF
--- a/wrappers/Python/CoolProp/Plots/Common.py
+++ b/wrappers/Python/CoolProp/Plots/Common.py
@@ -75,7 +75,7 @@ def get_critical_point(state):
 
 def interpolate_values_1d(x, y, x_points=None, kind='linear'):
     try:
-        from scipy.interpolate.interpolate import interp1d
+        from scipy.interpolate import interp1d
         if x_points is None:
             return interp1d(x, y, kind=kind)(x[np.isfinite(x)])
         else:


### PR DESCRIPTION
changes scipy.interpolate namespace (Deprecated)

### Requirements

### Description of the Change
Changed namespace for scipy interp1d due to deprecation warning 

DeprecationWarning: Please use `interp1d` from the `scipy.interpolate` namespace, the `scipy.interpolate.interpolate` namespace is deprecated.
    from scipy.interpolate.interpolate import interp1d

### Benefits
Avoid warning and future breaking of functionality

### Possible Drawbacks
Not tested

### Verification Process
Not tested 

### Applicable Issues

[ *Enter any applicable Issues here.  Use ``Closes #????`` if this PR closes an open issue.* ]
